### PR TITLE
TypeScript add @packageDocumentation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,8 @@
  * Refer to the TypeScript documentation at
  * https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require
  * to understand common workarounds for this limitation of ES6 modules.
+ *
+ * @packageDocumentation
  */
 
 /**


### PR DESCRIPTION
This fix is to prevent this wanring.

```
[INFO] Warning: Specifying multiple comments at the start of a file to use the first comment as the comment for the module has been deprecated. Use @module or @packageDocumentation instead.
[INFO]  C:/dev/primetek/primefaces/primefaces/src/main/type-definitions/node_modules/autonumeric/index.d.ts
```